### PR TITLE
Prepared single-plan static page with means to see plan score

### DIFF
--- a/planscore/after_upload.py
+++ b/planscore/after_upload.py
@@ -23,7 +23,7 @@ def put_upload_index(s3, bucket, upload):
     body = upload.to_json().encode('utf8')
 
     s3.put_object(Bucket=bucket, Key=key, Body=body,
-        ContentType='text/json', ACL='private')
+        ContentType='text/json', ACL='public-read')
 
 def get_redirect_url(website_base, id):
     '''

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -42,7 +42,7 @@ class TestAfterUpload (unittest.TestCase):
         s3.put_object.assert_called_once_with(Bucket=bucket,
             Key=upload.index_key.return_value,
             Body=upload.to_json.return_value.encode.return_value,
-            ACL='private', ContentType='text/json')
+            ACL='public-read', ContentType='text/json')
     
     def test_get_redirect_url(self):
         '''

--- a/planscore/upload_fields.py
+++ b/planscore/upload_fields.py
@@ -12,9 +12,10 @@ def get_upload_fields(s3, creds, request_url, secret):
     redirect_query = urllib.parse.urlencode(dict(id=signed_id))
     redirect_path = '{}?{}'.format(AFTER_PATH, redirect_query)
     acl, redirect_url = 'private', urllib.parse.urljoin(request_url, redirect_path)
+    bucket = os.environ.get('S3_BUCKET', 'planscore')
     
     presigned = s3.generate_presigned_post(
-        'planscore', data.UPLOAD_PREFIX.format(id=unsigned_id) + '${filename}',
+        bucket, data.UPLOAD_PREFIX.format(id=unsigned_id) + '${filename}',
         ExpiresIn=300,
         Conditions=[
             {"acl": acl},

--- a/planscore/website/__init__.py
+++ b/planscore/website/__init__.py
@@ -13,3 +13,7 @@ def get_upload():
     planscore_api_base = app.config['PLANSCORE_API_BASE']
     upload_fields_url = urllib.parse.urljoin(planscore_api_base, 'upload')
     return flask.render_template('upload.html', upload_fields_url=upload_fields_url)
+
+@app.route('/plan.html')
+def get_plan():
+    return 'A man, a plan, a canal: Panama'

--- a/planscore/website/__init__.py
+++ b/planscore/website/__init__.py
@@ -1,7 +1,9 @@
 import flask, os, urllib.parse
+from .. import data
 
 app = flask.Flask(__name__)
 
+app.config['PLANSCORE_S3_BUCKET'] = os.environ.get('S3_BUCKET', 'planscore')
 app.config['PLANSCORE_API_BASE'] = os.environ.get('API_BASE', 'https://api.planscore.org/')
 
 @app.route('/')
@@ -10,10 +12,11 @@ def get_index():
 
 @app.route('/upload.html')
 def get_upload():
-    planscore_api_base = app.config['PLANSCORE_API_BASE']
+    planscore_api_base = flask.current_app.config['PLANSCORE_API_BASE']
     upload_fields_url = urllib.parse.urljoin(planscore_api_base, 'upload')
     return flask.render_template('upload.html', upload_fields_url=upload_fields_url)
 
 @app.route('/plan.html')
 def get_plan():
-    return 'A man, a plan, a canal: Panama'
+    return 'A man, a plan, a canal: Panama\n{}\n{}\n'.format(
+        data.UPLOAD_INDEX_KEY, flask.current_app.config['PLANSCORE_S3_BUCKET'])


### PR DESCRIPTION
Also set up CORS configuration on `planscore` bucket in preparation. Part of #13.