### PR TITLE
Dark-launch new PlanScore-RunDistricts function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ live-lambda: planscore-lambda.zip
 	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-UploadFields --handler lambda.upload_fields >> /dev/null
 	aws --region us-east-1 lambda update-function-code --function-name PlanScore-AfterUpload --zip-file fileb://planscore-lambda.zip >> /dev/null
 	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-AfterUpload --handler lambda.after_upload >> /dev/null
+	aws --region us-east-1 lambda update-function-code --function-name PlanScore-RunDistrict --zip-file fileb://planscore-lambda.zip >> /dev/null
+	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-RunDistrict --handler lambda.run_district >> /dev/null
 
 live-website: planscore/website/build
 	aws s3 sync --acl public-read --cache-control 'public, max-age=300' --delete $</ s3://planscore-website/

--- a/circle.yml
+++ b/circle.yml
@@ -21,9 +21,3 @@ deployment:
     commands:
       - make live-lambda
       - make live-website
-  production:
-    branch: [migurski/support-north-carolina]
-    commands:
-      - make planscore-lambda.zip
-      - aws --region us-east-1 lambda update-function-code --function-name PlanScore-RunDistrict --zip-file fileb://planscore-lambda.zip >> /dev/null
-      - aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-RunDistrict --handler lambda.run_district >> /dev/null

--- a/circle.yml
+++ b/circle.yml
@@ -21,3 +21,9 @@ deployment:
     commands:
       - make live-lambda
       - make live-website
+  production:
+    branch: [migurski/support-north-carolina]
+    commands:
+      - make planscore-lambda.zip
+      - aws --region us-east-1 lambda update-function-code --function-name PlanScore-RunDistrict --zip-file fileb://planscore-lambda.zip >> /dev/null
+      - aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-RunDistrict --handler lambda.run_district >> /dev/null

--- a/lambda.py
+++ b/lambda.py
@@ -1,2 +1,3 @@
 from planscore.after_upload import lambda_handler as after_upload
 from planscore.upload_fields import lambda_handler as upload_fields
+from planscore.districts import lambda_handler as run_district

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -5,6 +5,8 @@ from . import prepare_state, score
 
 ogr.UseExceptions()
 
+FUNCTION_NAME = 'PlanScore-RunDistrict'
+
 class Storage:
     ''' Wrapper for S3-related details.
     '''

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -1,0 +1,18 @@
+def load_tile_precincts(tile):
+    '''
+    '''
+    return tile
+
+def iterate_precincts(precincts, tiles):
+    ''' Generate a stream of precincts, getting new ones from tiles as needed.
+    '''
+    while precincts or tiles:
+        if precincts:
+            # There is a precincts to yield.
+            precinct = precincts.pop(0)
+            yield precinct
+    
+        if tiles and not precincts:
+            # All out of precincts; fill up from the next tile.
+            more_precincts = load_tile_precincts(tiles.pop(0))
+            precincts.extend(more_precincts)

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -1,7 +1,7 @@
 import collections, json, io, gzip
 from osgeo import ogr
 import boto3, botocore.exceptions
-from . import prepare_state
+from . import prepare_state, score
 
 ogr.UseExceptions()
 
@@ -36,7 +36,13 @@ def consume_tiles(s3, bucket, tiles_prefix, totals, precincts, tiles):
 def score_precinct(totals, precinct):
     '''
     '''
-    totals['Voters'] += precinct['Voters']
+    #overlap_area = overlap_geom.Area() / precinct_geom.Area()
+    #precinct_fraction = overlap_area * feature.GetField(prepare_state.FRACTION_FIELD)
+    precinct_fraction = precinct['properties'][prepare_state.FRACTION_FIELD]
+    
+    for name in score.FIELD_NAMES:
+        precinct_value = precinct_fraction * precinct['properties'][name]
+        totals[name] += precinct_value
 
 def load_tile_precincts(s3, bucket, tiles_prefix, tile_zxy):
     ''' Get GeoJSON features for a specific tile.

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -1,3 +1,17 @@
+def consume_tiles(totals, precincts, tiles):
+    ''' Generate a stream of steps, updating totals from precincts and tiles.
+    
+        Inputs are modified directly, and lists should be empty at completion.
+    '''
+    for precinct in iterate_precincts(precincts, tiles):
+        score_precinct(totals, precinct)
+        yield
+
+def score_precinct(totals, precinct):
+    '''
+    '''
+    totals['Voters'] += precinct['Voters']
+
 def load_tile_precincts(tile):
     '''
     '''
@@ -5,6 +19,8 @@ def load_tile_precincts(tile):
 
 def iterate_precincts(precincts, tiles):
     ''' Generate a stream of precincts, getting new ones from tiles as needed.
+    
+        Input lists are modified directly, and should be empty at completion.
     '''
     while precincts or tiles:
         if precincts:

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -46,7 +46,6 @@ def score_precinct(totals, district_geom, precinct):
         else:
             raise
     overlap_area = overlap_geom.Area() / precinct_geom.Area()
-    print('overlap_area:', overlap_area, precinct['properties']['NAME'])
     precinct_fraction = overlap_area * precinct['properties'][prepare_state.FRACTION_FIELD]
     
     for name in score.FIELD_NAMES:

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -1,3 +1,24 @@
+import collections
+from osgeo import ogr
+from . import prepare_state
+
+ogr.UseExceptions()
+
+def lambda_handler(event, context):
+    '''
+    '''
+    if 'totals' in event and 'precincts' in event and 'tiles' in event:
+        totals, precincts, tiles = event['totals'], event['precincts'], event['tiles']
+    elif 'geometry' in event:
+        geometry = ogr.CreateGeometryFromWkt(event['geometry'])
+        totals, precincts, tiles = collections.defaultdict(int), [], \
+            get_geometry_tile_zxys(geometry)
+    else:
+        raise RuntimeError('Missing required totals, precincts, tiles, and geometry')
+    
+    for _ in consume_tiles(totals, precincts, tiles):
+        print('Iteration:', json.dumps(dict(totals=totals, precincts=precincts, tiles=tiles)))
+
 def consume_tiles(totals, precincts, tiles):
     ''' Generate a stream of steps, updating totals from precincts and tiles.
     
@@ -24,7 +45,7 @@ def iterate_precincts(precincts, tiles):
     '''
     while precincts or tiles:
         if precincts:
-            # There is a precincts to yield.
+            # There is a precinct to yield.
             precinct = precincts.pop(0)
             yield precinct
     
@@ -32,3 +53,22 @@ def iterate_precincts(precincts, tiles):
             # All out of precincts; fill up from the next tile.
             more_precincts = load_tile_precincts(tiles.pop(0))
             precincts.extend(more_precincts)
+
+def get_geometry_tile_zxys(district_geom):
+    ''' Return a list of expected tile Z/X/Y strings.
+    '''
+    if district_geom.GetSpatialReference():
+        district_geom.TransformTo(prepare_state.EPSG4326)
+    
+    xxyy_extent = district_geom.GetEnvelope()
+    iter = prepare_state.iter_extent_tiles(xxyy_extent, prepare_state.TILE_ZOOM)
+    tiles = []
+
+    for (coord, tile_wkt) in iter:
+        tile_zxy = '{zoom}/{column}/{row}'.format(**coord.__dict__)
+        tile_geom = ogr.CreateGeometryFromWkt(tile_wkt)
+        
+        if tile_geom.Intersects(district_geom):
+            tiles.append(tile_zxy)
+    
+    return tiles

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -1,4 +1,4 @@
-import collections
+import collections, json
 from osgeo import ogr
 from . import prepare_state
 

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -2,10 +2,37 @@ import unittest
 from .. import districts
 
 class TestDistricts (unittest.TestCase):
+
+    @unittest.mock.patch('planscore.districts.score_precinct')
+    def test_consume_tiles(self, score_precinct):
+        ''' Expected updates are made to totals dictionary.
+        '''
+        cases = [
+            ({'Voters': 0}, [], [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]),
+            ({'Voters': 0}, [{'Voters': 1}, {'Voters': 2}], [({'Voters': 4}, {'Voters': 8})]),
+            ({'Voters': 0}, [{'Voters': 1}, {'Voters': 2}, {'Voters': 4}, {'Voters': 8}], []),
+            ({'Voters': 3}, [{'Voters': 4}, {'Voters': 8}], []),
+            ({'Voters': 15}, [], []),
+            ]
+        
+        def mock_score_precinct(totals, precinct):
+            totals['Voters'] += precinct['Voters']
+        
+        score_precinct.side_effect = mock_score_precinct
+        expected_calls = 0
+        
+        for (totals, precincts, tiles) in cases:
+            iterations = list(districts.consume_tiles(totals, precincts, tiles))
+            expected_calls += len(iterations)
+            self.assertFalse(precincts, 'Precincts should be completely emptied')
+            self.assertFalse(tiles, 'Tiles should be completely emptied')
+            self.assertEqual(totals['Voters'], 15)
+        
+        self.assertEqual(len(score_precinct.mock_calls), expected_calls)
     
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     def test_iterate_precincts(self, load_tile_precincts):
-        ''' Expected list of precincts comes back from pairs of lists.
+        ''' Expected list of precincts comes back from a pair of lists.
         '''
         cases = [
             ([],        [],                 []),

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -1,7 +1,24 @@
-import unittest
+import unittest, os, json
+from osgeo import ogr
 from .. import districts
 
 class TestDistricts (unittest.TestCase):
+
+    @unittest.mock.patch('planscore.districts.consume_tiles')
+    def test_lambda_handler_init(self, consume_tiles):
+        ''' Lambda event data with just geometry starts the process.
+        '''
+        event = {'geometry': 'POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'}
+        districts.lambda_handler(event, None)
+        self.assertEqual(consume_tiles.mock_calls[0][1], ({}, [], ['10/511/511', '10/511/512']))
+
+    @unittest.mock.patch('planscore.districts.consume_tiles')
+    def test_lambda_handler_continue(self, consume_tiles):
+        ''' Lambda event data with existing totals continues the process.
+        '''
+        event = {'totals': {}, 'precincts': [{'Totals': 1}], 'tiles': ['10/511/512']}
+        districts.lambda_handler(event, None)
+        self.assertEqual(consume_tiles.mock_calls[0][1], ({}, [{'Totals': 1}], ['10/511/512']))
 
     @unittest.mock.patch('planscore.districts.score_precinct')
     def test_consume_tiles(self, score_precinct):
@@ -30,6 +47,40 @@ class TestDistricts (unittest.TestCase):
         
         self.assertEqual(len(score_precinct.mock_calls), expected_calls)
     
+    @unittest.mock.patch('planscore.districts.score_precinct')
+    def test_consume_tiles_detail(self, score_precinct):
+        ''' Expected updates are made to totals dictionary and lists.
+        '''
+        def mock_score_precinct(totals, precinct):
+            totals['Voters'] += precinct['Voters']
+        
+        score_precinct.side_effect = mock_score_precinct
+
+        totals, precincts, tiles = {'Voters': 0}, [], \
+            [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]
+        
+        call = districts.consume_tiles(totals, precincts, tiles)
+        self.assertEqual((totals, precincts, tiles), ({'Voters': 0}, [],
+            [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]))
+        
+        next(call)
+        self.assertEqual((totals, precincts, tiles), ({'Voters': 1},
+            [{'Voters': 2}], [({'Voters': 4}, {'Voters': 8})]))
+        
+        next(call)
+        self.assertEqual((totals, precincts, tiles), ({'Voters': 3}, [],
+            [({'Voters': 4}, {'Voters': 8})]))
+        
+        next(call)
+        self.assertEqual((totals, precincts, tiles), ({'Voters': 7},
+            [{'Voters': 8}], []))
+        
+        next(call)
+        self.assertEqual((totals, precincts, tiles), ({'Voters': 15}, [], []))
+
+        with self.assertRaises(StopIteration):
+            next(call)
+    
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     def test_iterate_precincts(self, load_tile_precincts):
         ''' Expected list of precincts comes back from a pair of lists.
@@ -55,3 +106,20 @@ class TestDistricts (unittest.TestCase):
             self.assertEqual(actual, expected)
         
         self.assertEqual(len(load_tile_precincts.mock_calls), expected_calls)
+
+    def test_get_geometry_tile_zxys(self):
+        ''' Get an expected list of Z/X/Y tile strings for a geometry.
+        '''
+        with open(os.path.join(os.path.dirname(__file__), 'data', 'null-plan.geojson')) as file:
+            geojson = json.load(file)
+        
+        feature1, feature2 = geojson['features']
+
+        geometry1 = ogr.CreateGeometryFromJson(json.dumps(feature1['geometry']))
+        done1 = districts.get_geometry_tile_zxys(geometry1)
+
+        geometry2 = ogr.CreateGeometryFromJson(json.dumps(feature2['geometry']))
+        done2 = districts.get_geometry_tile_zxys(geometry2)
+        
+        self.assertEqual(done1, ['10/511/511', '10/511/512'])
+        self.assertEqual(done2, ['10/511/511', '10/512/511', '10/511/512', '10/512/512'])

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -26,8 +26,9 @@ class TestDistricts (unittest.TestCase):
         '''
         event = {'geometry': 'POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'}
         districts.lambda_handler(event, None)
+        partial = consume_tiles.mock_calls[0][1][3]
         self.assertEqual(consume_tiles.mock_calls[0][1][1:3], (None, None))
-        self.assertEqual(consume_tiles.mock_calls[0][1][4:],
+        self.assertEqual((partial.totals, partial.precincts, partial.tiles),
             ({}, [], ['10/511/511', '10/511/512']))
 
     @unittest.mock.patch('planscore.districts.consume_tiles')
@@ -37,8 +38,9 @@ class TestDistricts (unittest.TestCase):
         event = {'totals': {}, 'precincts': [{'Totals': 1}], 'tiles': ['10/511/512'],
             'geometry': 'POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'}
         districts.lambda_handler(event, None)
+        partial = consume_tiles.mock_calls[0][1][3]
         self.assertEqual(consume_tiles.mock_calls[0][1][1:3], (None, None))
-        self.assertEqual(consume_tiles.mock_calls[0][1][4:],
+        self.assertEqual((partial.totals, partial.precincts, partial.tiles),
             ({}, [{'Totals': 1}], ['10/511/512']))
 
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
@@ -46,7 +48,7 @@ class TestDistricts (unittest.TestCase):
     def test_consume_tiles(self, score_precinct, load_tile_precincts):
         ''' Expected updates are made to totals dictionary.
         '''
-        s3, bucket, tiles_prefix, district_geom = None, None, None, None
+        s3, bucket, tiles_prefix = None, None, None
 
         cases = [
             ({'Voters': 0}, [], [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]),
@@ -56,8 +58,8 @@ class TestDistricts (unittest.TestCase):
             ({'Voters': 15}, [], []),
             ]
         
-        def mock_score_precinct(totals, district_geom, precinct):
-            totals['Voters'] += precinct['Voters']
+        def mock_score_precinct(partial, precinct):
+            partial.totals['Voters'] += precinct['Voters']
         
         # Just use the identity function to extend precincts
         load_tile_precincts.side_effect = lambda s3, bucket, tiles_prefix, tile: tile
@@ -65,11 +67,12 @@ class TestDistricts (unittest.TestCase):
         expected_calls = 0
         
         for (totals, precincts, tiles) in cases:
-            iterations = list(districts.consume_tiles(s3, bucket, tiles_prefix, district_geom, totals, precincts, tiles))
+            partial = districts.Partial(totals, precincts, tiles, None)
+            iterations = list(districts.consume_tiles(s3, bucket, tiles_prefix, partial))
             expected_calls += len(iterations)
-            self.assertFalse(precincts, 'Precincts should be completely emptied')
-            self.assertFalse(tiles, 'Tiles should be completely emptied')
-            self.assertEqual(totals['Voters'], 15)
+            self.assertFalse(partial.precincts, 'Precincts should be completely emptied')
+            self.assertFalse(partial.tiles, 'Tiles should be completely emptied')
+            self.assertEqual(partial.totals['Voters'], 15)
         
         self.assertEqual(len(score_precinct.mock_calls), expected_calls)
     
@@ -78,10 +81,10 @@ class TestDistricts (unittest.TestCase):
     def test_consume_tiles_detail(self, score_precinct, load_tile_precincts):
         ''' Expected updates are made to totals dictionary and lists.
         '''
-        s3, bucket, tiles_prefix, district_geom = None, None, None, None
+        s3, bucket, tiles_prefix = None, None, None
 
-        def mock_score_precinct(totals, district_geom, precinct):
-            totals['Voters'] += precinct['Voters']
+        def mock_score_precinct(partial, precinct):
+            partial.totals['Voters'] += precinct['Voters']
         
         # Just use the identity function to extend precincts
         load_tile_precincts.side_effect = lambda s3, bucket, tiles_prefix, tile: tile
@@ -90,24 +93,26 @@ class TestDistricts (unittest.TestCase):
         totals, precincts, tiles = {'Voters': 0}, [], \
             [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]
         
-        call = districts.consume_tiles(s3, bucket, tiles_prefix, district_geom, totals, precincts, tiles)
-        self.assertEqual((totals, precincts, tiles), ({'Voters': 0}, [],
-            [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]))
+        partial = districts.Partial(totals, precincts, tiles, None)
+        call = districts.consume_tiles(s3, bucket, tiles_prefix, partial)
+        self.assertEqual((partial.totals, partial.precincts, partial.tiles),
+            ({'Voters': 0}, [], [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]))
         
         next(call)
-        self.assertEqual((totals, precincts, tiles), ({'Voters': 1},
-            [{'Voters': 2}], [({'Voters': 4}, {'Voters': 8})]))
+        self.assertEqual((partial.totals, partial.precincts, partial.tiles),
+            ({'Voters': 1}, [{'Voters': 2}], [({'Voters': 4}, {'Voters': 8})]))
         
         next(call)
-        self.assertEqual((totals, precincts, tiles), ({'Voters': 3}, [],
-            [({'Voters': 4}, {'Voters': 8})]))
+        self.assertEqual((partial.totals, partial.precincts, partial.tiles),
+            ({'Voters': 3}, [], [({'Voters': 4}, {'Voters': 8})]))
         
         next(call)
-        self.assertEqual((totals, precincts, tiles), ({'Voters': 7},
-            [{'Voters': 8}], []))
+        self.assertEqual((partial.totals, partial.precincts, partial.tiles),
+            ({'Voters': 7}, [{'Voters': 8}], []))
         
         next(call)
-        self.assertEqual((totals, precincts, tiles), ({'Voters': 15}, [], []))
+        self.assertEqual((partial.totals, partial.precincts, partial.tiles),
+            ({'Voters': 15}, [], []))
 
         with self.assertRaises(StopIteration):
             next(call)
@@ -118,11 +123,12 @@ class TestDistricts (unittest.TestCase):
         totals = {"Voters": 0, "Red Votes": 0, "Blue Votes": 0}
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))')
         precinct = {"type": "Feature", "properties": {"GEOID": "3", "NAME": "Precinct 3", "Voters": 4, "Red Votes": 3, "Blue Votes": 0, "PlanScore:Fraction": 0.563558429345361}, "geometry": {"type": "Polygon", "coordinates": [[[-0.0003853, 0.0], [-0.0003819, 2.5e-06], [-0.0003824, 1.16e-05], [-0.0003895, 1.16e-05], [-0.000391, 1.47e-05], [-0.0003922, 2.1e-05], [-0.0003832, 3.27e-05], [-0.0003844, 3.81e-05], [-0.0003751, 5.2e-05], [-0.0003683, 5.48e-05], [-0.0003685, 5.99e-05], [-0.0003642, 6.45e-05], [-0.0003597, 6.45e-05], [-0.0003531, 6.45e-05], [-0.0003432, 6.91e-05], [-0.0003379, 6.96e-05], [-0.0003321, 7.06e-05], [-0.0003273, 7.72e-05], [-0.0003268, 8.46e-05], [-0.0003185, 8.97e-05], [-0.0003109, 9.04e-05], [-0.0003064, 9.5e-05], [-0.0002973, 9.45e-05], [-0.0002978, 0.0001047], [-0.0002887, 0.0001103], [-0.0002826, 0.0001067], [-0.0002746, 0.0001042], [-0.0002756, 0.0001164], [-0.0002852, 0.0001179], [-0.0002852, 0.0001245], [-0.0002776, 0.0001291], [-0.0002776, 0.0001438], [-0.0002756, 0.0001464], [-0.00027, 0.0001474], [-0.0002644, 0.0001606], [-0.0002619, 0.0001657], [-0.0002518, 0.0001632], [-0.0002463, 0.0001738], [-0.0002397, 0.0001728], [-0.0002286, 0.0001815], [-0.0002225, 0.0001815], [-0.0002205, 0.0001922], [-0.0002154, 0.0001947], [-0.0002114, 0.0002049], [-0.0001973, 0.0002166], [-0.0001952, 0.0002237], [-0.0001811, 0.0002181], [-0.0001821, 0.000213], [-0.0001882, 0.0002038], [-0.0001856, 0.0001988], [-0.0001856, 0.0001942], [-0.0001882, 0.000184], [-0.0001826, 0.000184], [-0.000176, 0.0001749], [-0.0001715, 0.0001754], [-0.0001634, 0.0001866], [-0.0001594, 0.0001876], [-0.0001538, 0.0001916], [-0.0001478, 0.0001855], [-0.0001382, 0.0001922], [-0.0001255, 0.0001906], [-0.000125, 0.000183], [-0.000118, 0.0001825], [-0.0001175, 0.0001898], [-3.16e-05, 0.0], [-0.0003853, 0.0]]]}}
-        districts.score_precinct(totals, geometry, precinct)
+        partial = districts.Partial(totals, None, None, geometry)
+        districts.score_precinct(partial, precinct)
         
-        self.assertAlmostEqual(totals['Voters'], 2.25423371)
-        self.assertAlmostEqual(totals['Red Votes'], 1.69067528)
-        self.assertAlmostEqual(totals['Blue Votes'], 0)
+        self.assertAlmostEqual(partial.totals['Voters'], 2.25423371)
+        self.assertAlmostEqual(partial.totals['Red Votes'], 1.69067528)
+        self.assertAlmostEqual(partial.totals['Blue Votes'], 0)
     
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     def test_iterate_precincts(self, load_tile_precincts):

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -8,10 +8,8 @@ should_gzip = itertools.cycle([True, False])
 def mock_s3_get_object(Bucket, Key):
     '''
     '''
-    print('mock_s3_get_object:', Bucket, Key)
     path = os.path.join(os.path.dirname(__file__), 'data', Key)
     if not os.path.exists(path):
-        print('botocore.exceptions.ClientError:', Key)
         raise botocore.exceptions.ClientError({'Error': {'Code': 'NoSuchKey'}}, 'GetObject')
     with open(path, 'rb') as file:
         if next(should_gzip):

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -71,8 +71,6 @@ class TestDistricts (unittest.TestCase):
             self.assertEqual(totals['Voters'], 15)
         
         self.assertEqual(len(score_precinct.mock_calls), expected_calls)
-        self.assertEqual([len(call[1]) for call in load_tile_precincts.mock_calls], [4, 4, 4],
-            'Every call to load_tile_precincts should have four arguments')
     
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     @unittest.mock.patch('planscore.districts.score_precinct')
@@ -112,6 +110,17 @@ class TestDistricts (unittest.TestCase):
 
         with self.assertRaises(StopIteration):
             next(call)
+    
+    def test_score_precinct(self):
+        ''' Correct values appears in totals dict after scoring a precinct.
+        '''
+        totals = {"Voters": 0, "Red Votes": 0, "Blue Votes": 0}
+        precinct = {"type": "Feature", "properties": {"GEOID": "2", "NAME": "Precinct 2", "Voters": 5, "Red Votes": 1, "Blue Votes": 3, "PlanScore:Fraction": 0.21941107029382734}, "geometry": {"type": "Polygon", "coordinates": [[[-3.16e-05, 0.0], [-0.0001175, 0.0001898], [-0.0001175, 0.0001911], [-0.0001048, 0.0001927], [-0.0001053, 0.0002125], [-0.0001084, 0.0002196], [-0.0001028, 0.0002211], [-0.0001023, 0.0002318], [-9.07e-05, 0.0002364], [-8.71e-05, 0.0002349], [-8.66e-05, 0.000242], [-8.26e-05, 0.0002471], [-7.45e-05, 0.0002486], [-6.49e-05, 0.0002394], [-5.94e-05, 0.0002384], [-5.78e-05, 0.0002354], [-4.02e-05, 0.0002344], [-3.86e-05, 0.0002425], [-2.96e-05, 0.000245], [-3.01e-05, 0.0002379], [-2.6e-05, 0.0002379], [-1.79e-05, 0.0002232], [-1.04e-05, 0.0002232], [-7.3e-06, 0.0002181], [-2.8e-06, 0.0002181], [-0.0, 0.0002153], [-0.0, 0.0], [-3.16e-05, 0.0]]]}}
+        districts.score_precinct(totals, precinct)
+        
+        self.assertAlmostEqual(totals['Voters'], 1.097055351)
+        self.assertAlmostEqual(totals['Red Votes'], 0.21941107)
+        self.assertAlmostEqual(totals['Blue Votes'], 0.658233211)
     
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     def test_iterate_precincts(self, load_tile_precincts):

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -1,0 +1,30 @@
+import unittest
+from .. import districts
+
+class TestDistricts (unittest.TestCase):
+    
+    @unittest.mock.patch('planscore.districts.load_tile_precincts')
+    def test_iterate_precincts(self, load_tile_precincts):
+        ''' Expected list of precincts comes back from pairs of lists.
+        '''
+        cases = [
+            ([],        [],                 []),
+            ([1, 2],    [],                 [1, 2]),
+            ([1, 2],    [(3, 4)],           [1, 2, 3, 4]),
+            ([1, 2],    [(3, 4), (5, 6)],   [1, 2, 3, 4, 5, 6]),
+            ([],        [(3, 4), (5, 6)],   [3, 4, 5, 6]),
+            ([],        [(5, 6)],           [5, 6]),
+            ]
+        
+        # Just use the identity function to extend precincts
+        load_tile_precincts.side_effect = lambda stuff: stuff
+        expected_calls = 0
+        
+        for (input, tiles, expected) in cases:
+            expected_calls += len(tiles)
+            actual = list(districts.iterate_precincts(input, tiles))
+            self.assertFalse(input, 'Input should be completely emptied')
+            self.assertFalse(tiles, 'Tiles should be completely emptied')
+            self.assertEqual(actual, expected)
+        
+        self.assertEqual(len(load_tile_precincts.mock_calls), expected_calls)

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -28,24 +28,27 @@ class TestDistricts (unittest.TestCase):
         '''
         event = {'geometry': 'POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'}
         districts.lambda_handler(event, None)
-        self.assertEqual(consume_tiles.mock_calls[0][1][1:],
-            (None, None, {}, [], ['10/511/511', '10/511/512']))
+        self.assertEqual(consume_tiles.mock_calls[0][1][1:3], (None, None))
+        self.assertEqual(consume_tiles.mock_calls[0][1][4:],
+            ({}, [], ['10/511/511', '10/511/512']))
 
     @unittest.mock.patch('planscore.districts.consume_tiles')
     def test_lambda_handler_continue(self, consume_tiles):
         ''' Lambda event data with existing totals continues the process.
         '''
-        event = {'totals': {}, 'precincts': [{'Totals': 1}], 'tiles': ['10/511/512']}
+        event = {'totals': {}, 'precincts': [{'Totals': 1}], 'tiles': ['10/511/512'],
+            'geometry': 'POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'}
         districts.lambda_handler(event, None)
-        self.assertEqual(consume_tiles.mock_calls[0][1][1:],
-            (None, None, {}, [{'Totals': 1}], ['10/511/512']))
+        self.assertEqual(consume_tiles.mock_calls[0][1][1:3], (None, None))
+        self.assertEqual(consume_tiles.mock_calls[0][1][4:],
+            ({}, [{'Totals': 1}], ['10/511/512']))
 
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     @unittest.mock.patch('planscore.districts.score_precinct')
     def test_consume_tiles(self, score_precinct, load_tile_precincts):
         ''' Expected updates are made to totals dictionary.
         '''
-        s3, bucket, tiles_prefix = None, None, None
+        s3, bucket, tiles_prefix, district_geom = None, None, None, None
 
         cases = [
             ({'Voters': 0}, [], [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]),
@@ -55,7 +58,7 @@ class TestDistricts (unittest.TestCase):
             ({'Voters': 15}, [], []),
             ]
         
-        def mock_score_precinct(totals, precinct):
+        def mock_score_precinct(totals, district_geom, precinct):
             totals['Voters'] += precinct['Voters']
         
         # Just use the identity function to extend precincts
@@ -64,7 +67,7 @@ class TestDistricts (unittest.TestCase):
         expected_calls = 0
         
         for (totals, precincts, tiles) in cases:
-            iterations = list(districts.consume_tiles(s3, bucket, tiles_prefix, totals, precincts, tiles))
+            iterations = list(districts.consume_tiles(s3, bucket, tiles_prefix, district_geom, totals, precincts, tiles))
             expected_calls += len(iterations)
             self.assertFalse(precincts, 'Precincts should be completely emptied')
             self.assertFalse(tiles, 'Tiles should be completely emptied')
@@ -77,9 +80,9 @@ class TestDistricts (unittest.TestCase):
     def test_consume_tiles_detail(self, score_precinct, load_tile_precincts):
         ''' Expected updates are made to totals dictionary and lists.
         '''
-        s3, bucket, tiles_prefix = None, None, None
+        s3, bucket, tiles_prefix, district_geom = None, None, None, None
 
-        def mock_score_precinct(totals, precinct):
+        def mock_score_precinct(totals, district_geom, precinct):
             totals['Voters'] += precinct['Voters']
         
         # Just use the identity function to extend precincts
@@ -89,7 +92,7 @@ class TestDistricts (unittest.TestCase):
         totals, precincts, tiles = {'Voters': 0}, [], \
             [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]
         
-        call = districts.consume_tiles(s3, bucket, tiles_prefix, totals, precincts, tiles)
+        call = districts.consume_tiles(s3, bucket, tiles_prefix, district_geom, totals, precincts, tiles)
         self.assertEqual((totals, precincts, tiles), ({'Voters': 0}, [],
             [({'Voters': 1}, {'Voters': 2}), ({'Voters': 4}, {'Voters': 8})]))
         
@@ -115,12 +118,13 @@ class TestDistricts (unittest.TestCase):
         ''' Correct values appears in totals dict after scoring a precinct.
         '''
         totals = {"Voters": 0, "Red Votes": 0, "Blue Votes": 0}
-        precinct = {"type": "Feature", "properties": {"GEOID": "2", "NAME": "Precinct 2", "Voters": 5, "Red Votes": 1, "Blue Votes": 3, "PlanScore:Fraction": 0.21941107029382734}, "geometry": {"type": "Polygon", "coordinates": [[[-3.16e-05, 0.0], [-0.0001175, 0.0001898], [-0.0001175, 0.0001911], [-0.0001048, 0.0001927], [-0.0001053, 0.0002125], [-0.0001084, 0.0002196], [-0.0001028, 0.0002211], [-0.0001023, 0.0002318], [-9.07e-05, 0.0002364], [-8.71e-05, 0.0002349], [-8.66e-05, 0.000242], [-8.26e-05, 0.0002471], [-7.45e-05, 0.0002486], [-6.49e-05, 0.0002394], [-5.94e-05, 0.0002384], [-5.78e-05, 0.0002354], [-4.02e-05, 0.0002344], [-3.86e-05, 0.0002425], [-2.96e-05, 0.000245], [-3.01e-05, 0.0002379], [-2.6e-05, 0.0002379], [-1.79e-05, 0.0002232], [-1.04e-05, 0.0002232], [-7.3e-06, 0.0002181], [-2.8e-06, 0.0002181], [-0.0, 0.0002153], [-0.0, 0.0], [-3.16e-05, 0.0]]]}}
-        districts.score_precinct(totals, precinct)
+        geometry = ogr.CreateGeometryFromWkt('POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))')
+        precinct = {"type": "Feature", "properties": {"GEOID": "3", "NAME": "Precinct 3", "Voters": 4, "Red Votes": 3, "Blue Votes": 0, "PlanScore:Fraction": 0.563558429345361}, "geometry": {"type": "Polygon", "coordinates": [[[-0.0003853, 0.0], [-0.0003819, 2.5e-06], [-0.0003824, 1.16e-05], [-0.0003895, 1.16e-05], [-0.000391, 1.47e-05], [-0.0003922, 2.1e-05], [-0.0003832, 3.27e-05], [-0.0003844, 3.81e-05], [-0.0003751, 5.2e-05], [-0.0003683, 5.48e-05], [-0.0003685, 5.99e-05], [-0.0003642, 6.45e-05], [-0.0003597, 6.45e-05], [-0.0003531, 6.45e-05], [-0.0003432, 6.91e-05], [-0.0003379, 6.96e-05], [-0.0003321, 7.06e-05], [-0.0003273, 7.72e-05], [-0.0003268, 8.46e-05], [-0.0003185, 8.97e-05], [-0.0003109, 9.04e-05], [-0.0003064, 9.5e-05], [-0.0002973, 9.45e-05], [-0.0002978, 0.0001047], [-0.0002887, 0.0001103], [-0.0002826, 0.0001067], [-0.0002746, 0.0001042], [-0.0002756, 0.0001164], [-0.0002852, 0.0001179], [-0.0002852, 0.0001245], [-0.0002776, 0.0001291], [-0.0002776, 0.0001438], [-0.0002756, 0.0001464], [-0.00027, 0.0001474], [-0.0002644, 0.0001606], [-0.0002619, 0.0001657], [-0.0002518, 0.0001632], [-0.0002463, 0.0001738], [-0.0002397, 0.0001728], [-0.0002286, 0.0001815], [-0.0002225, 0.0001815], [-0.0002205, 0.0001922], [-0.0002154, 0.0001947], [-0.0002114, 0.0002049], [-0.0001973, 0.0002166], [-0.0001952, 0.0002237], [-0.0001811, 0.0002181], [-0.0001821, 0.000213], [-0.0001882, 0.0002038], [-0.0001856, 0.0001988], [-0.0001856, 0.0001942], [-0.0001882, 0.000184], [-0.0001826, 0.000184], [-0.000176, 0.0001749], [-0.0001715, 0.0001754], [-0.0001634, 0.0001866], [-0.0001594, 0.0001876], [-0.0001538, 0.0001916], [-0.0001478, 0.0001855], [-0.0001382, 0.0001922], [-0.0001255, 0.0001906], [-0.000125, 0.000183], [-0.000118, 0.0001825], [-0.0001175, 0.0001898], [-3.16e-05, 0.0], [-0.0003853, 0.0]]]}}
+        districts.score_precinct(totals, geometry, precinct)
         
-        self.assertAlmostEqual(totals['Voters'], 1.097055351)
-        self.assertAlmostEqual(totals['Red Votes'], 0.21941107)
-        self.assertAlmostEqual(totals['Blue Votes'], 0.658233211)
+        self.assertAlmostEqual(totals['Voters'], 2.25423371)
+        self.assertAlmostEqual(totals['Red Votes'], 1.69067528)
+        self.assertAlmostEqual(totals['Blue Votes'], 0)
     
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     def test_iterate_precincts(self, load_tile_precincts):


### PR DESCRIPTION
To support larger states like North Carolina, we’ll need to run processes longer than the AWS 5 minute limit. A new `PlanScore-RunDistricts` function will process each district in parallel, and will be invoked as an event to run in the background. Currently, this new function no-ops into the logs but it can be observed. Part of #21.