### PR TITLE
Fixed some problems in self-invoking Lambda function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ all: planscore/website/build
 
 live-lambda: planscore-lambda.zip
 	aws --region us-east-1 lambda update-function-code --function-name PlanScore-UploadFields --zip-file fileb://planscore-lambda.zip >> /dev/null
-	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-UploadFields --handler lambda.upload_fields >> /dev/null
+	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-UploadFields --handler lambda.upload_fields --timeout 3 >> /dev/null
 	aws --region us-east-1 lambda update-function-code --function-name PlanScore-AfterUpload --zip-file fileb://planscore-lambda.zip >> /dev/null
-	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-AfterUpload --handler lambda.after_upload >> /dev/null
+	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-AfterUpload --handler lambda.after_upload --timeout 30 >> /dev/null
 	aws --region us-east-1 lambda update-function-code --function-name PlanScore-RunDistrict --zip-file fileb://planscore-lambda.zip >> /dev/null
-	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-RunDistrict --handler lambda.run_district >> /dev/null
+	aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-RunDistrict --handler lambda.run_district --timeout 300 >> /dev/null
 
 live-website: planscore/website/build
 	aws s3 sync --acl public-read --cache-control 'public, max-age=300' --delete $</ s3://planscore-website/

--- a/circle.yml
+++ b/circle.yml
@@ -21,9 +21,3 @@ deployment:
     commands:
       - make live-lambda
       - make live-website
-  production:
-    branch: [migurski/support-north-carolina]
-    commands:
-      - make planscore-lambda.zip
-      - aws --region us-east-1 lambda update-function-code --function-name PlanScore-RunDistrict --zip-file fileb://planscore-lambda.zip >> /dev/null
-      - aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-RunDistrict --handler lambda.run_district >> /dev/null

--- a/circle.yml
+++ b/circle.yml
@@ -21,3 +21,9 @@ deployment:
     commands:
       - make live-lambda
       - make live-website
+  production:
+    branch: [migurski/support-north-carolina]
+    commands:
+      - make planscore-lambda.zip
+      - aws --region us-east-1 lambda update-function-code --function-name PlanScore-RunDistrict --zip-file fileb://planscore-lambda.zip >> /dev/null
+      - aws --region us-east-1 lambda update-function-configuration --function-name PlanScore-RunDistrict --handler lambda.run_district >> /dev/null

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -76,9 +76,10 @@ def lambda_handler(event, context):
         
         stdev = statistics.stdev(times) if len(times) > 1 else times[0]
         cutoff_msec = 1000 * (statistics.mean(times) + 3 * stdev)
+        remain_msec = context.get_remaining_time_in_millis() - 5000 # 5 seconds for Lambda
         
-        print('Checking if remaining msec', context.get_remaining_time_in_millis(), '> cutoff msec', cutoff_msec)
-        if context.get_remaining_time_in_millis() > cutoff_msec:
+        print('Checking if remaining msec', remain_msec, '> cutoff msec', cutoff_msec)
+        if remain_msec > cutoff_msec:
             # There's time to do more
             continue
 
@@ -89,7 +90,7 @@ def lambda_handler(event, context):
         lam.invoke(FunctionName=FUNCTION_NAME, InvocationType='Event',
             Payload=json.dumps(event).encode('utf8'))
 
-        print('Stopping with', context.get_remaining_time_in_millis(), 'msec remaining')
+        print('Stopping with', remain_msec, 'msec remaining')
         return
     
     key = partial.upload.district_key(partial.index)

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -93,7 +93,7 @@ def lambda_handler(event, context):
         
         stdev = statistics.stdev(times) if len(times) > 1 else times[0]
         cutoff_msec = 1000 * (statistics.mean(times) + 3 * stdev)
-        remain_msec = context.get_remaining_time_in_millis() - 5000 # 5 seconds for Lambda
+        remain_msec = context.get_remaining_time_in_millis() - 10000 # 10 seconds for Lambda
         
         print('Checking if remaining msec', remain_msec, '> cutoff msec', cutoff_msec)
         if remain_msec > cutoff_msec:

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -120,6 +120,7 @@ def score_precinct(partial, precinct):
             # Sometimes, a precinct geometry can be invalid
             # so inflate it by a tiny amount to smooth out problems
             precinct_geom = precinct_geom.Buffer(0.0000001)
+            overlap_geom = precinct_geom.Intersection(partial.geometry)
         else:
             raise
     overlap_area = overlap_geom.Area() / precinct_geom.Area()

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -77,6 +77,7 @@ def lambda_handler(event, context):
         stdev = statistics.stdev(times) if len(times) > 1 else times[0]
         cutoff_msec = 1000 * (statistics.mean(times) + 3 * stdev)
         
+        print('Checking if remaining msec', context.get_remaining_time_in_millis(), '> cutoff msec', cutoff_msec)
         if context.get_remaining_time_in_millis() > cutoff_msec:
             # There's time to do more
             continue

--- a/planscore/score.py
+++ b/planscore/score.py
@@ -82,6 +82,7 @@ def score_district(s3, bucket, district_geom, tiles_prefix):
                         # Sometimes, a precinct geometry can be invalid
                         # so inflate it by a tiny amount to smooth out problems
                         precinct_geom = precinct_geom.Buffer(0.0000001)
+                        overlap_geom = precinct_geom.Intersection(district_geom)
                     else:
                         raise
                 overlap_area = overlap_geom.Area() / precinct_geom.Area()

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -84,7 +84,7 @@ class TestDistricts (unittest.TestCase):
 
         boto3_client.return_value.put_object.assert_called_once_with(
             Key='uploads/ID/districts/-1.json', Body=b'{}', ACL='private',
-            Bucket=None, ContentEncoding='gzip', ContentType='text/json')
+            Bucket=None, ContentType='text/json')
 
     @unittest.mock.patch('boto3.client')
     @unittest.mock.patch('planscore.districts.consume_tiles')
@@ -128,7 +128,7 @@ class TestDistricts (unittest.TestCase):
 
         boto3_client.return_value.put_object.assert_called_once_with(
             Key='uploads/ID/districts/-1.json', Body=b'{}', ACL='private',
-            Bucket=None, ContentEncoding='gzip', ContentType='text/json')
+            Bucket=None, ContentType='text/json')
 
     @unittest.mock.patch('planscore.districts.load_tile_precincts')
     @unittest.mock.patch('planscore.districts.score_precinct')

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -40,6 +40,34 @@ class TestDistricts (unittest.TestCase):
         self.assertEqual(partial.precincts, [])
         self.assertEqual(partial.tiles, ['10/512/511'])
         self.assertEqual(partial.upload.id, 'ID')
+    
+    def test_Partial_to_event(self):
+        ''' Partial.to_event() and .from_event() work together.
+        '''
+        partial1 = districts.Partial(0, {},
+            [{"type": "Feature", "properties": {"GEOID": "3", "NAME": "Precinct 3", "Voters": 4, "Red Votes": 3, "Blue Votes": 0, "PlanScore:Fraction": 0.563558429345361}, "geometry": {"type": "Polygon", "coordinates": [[[-0.0003853, 0.0], [-0.0003819, 2.5e-06], [-0.0003824, 1.16e-05], [-0.0003895, 1.16e-05], [-0.000391, 1.47e-05], [-0.0003922, 2.1e-05], [-0.0003832, 3.27e-05], [-0.0003844, 3.81e-05], [-0.0003751, 5.2e-05], [-0.0003683, 5.48e-05], [-0.0003685, 5.99e-05], [-0.0003642, 6.45e-05], [-0.0003597, 6.45e-05], [-0.0003531, 6.45e-05], [-0.0003432, 6.91e-05], [-0.0003379, 6.96e-05], [-0.0003321, 7.06e-05], [-0.0003273, 7.72e-05], [-0.0003268, 8.46e-05], [-0.0003185, 8.97e-05], [-0.0003109, 9.04e-05], [-0.0003064, 9.5e-05], [-0.0002973, 9.45e-05], [-0.0002978, 0.0001047], [-0.0002887, 0.0001103], [-0.0002826, 0.0001067], [-0.0002746, 0.0001042], [-0.0002756, 0.0001164], [-0.0002852, 0.0001179], [-0.0002852, 0.0001245], [-0.0002776, 0.0001291], [-0.0002776, 0.0001438], [-0.0002756, 0.0001464], [-0.00027, 0.0001474], [-0.0002644, 0.0001606], [-0.0002619, 0.0001657], [-0.0002518, 0.0001632], [-0.0002463, 0.0001738], [-0.0002397, 0.0001728], [-0.0002286, 0.0001815], [-0.0002225, 0.0001815], [-0.0002205, 0.0001922], [-0.0002154, 0.0001947], [-0.0002114, 0.0002049], [-0.0001973, 0.0002166], [-0.0001952, 0.0002237], [-0.0001811, 0.0002181], [-0.0001821, 0.000213], [-0.0001882, 0.0002038], [-0.0001856, 0.0001988], [-0.0001856, 0.0001942], [-0.0001882, 0.000184], [-0.0001826, 0.000184], [-0.000176, 0.0001749], [-0.0001715, 0.0001754], [-0.0001634, 0.0001866], [-0.0001594, 0.0001876], [-0.0001538, 0.0001916], [-0.0001478, 0.0001855], [-0.0001382, 0.0001922], [-0.0001255, 0.0001906], [-0.000125, 0.000183], [-0.000118, 0.0001825], [-0.0001175, 0.0001898], [-3.16e-05, 0.0], [-0.0003853, 0.0]]]}}],
+            ["whatever"], ogr.CreateGeometryFromWkt('POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'),
+            data.Upload('ID', 'key.json'))
+        
+        partial2 = districts.Partial.from_event(partial1.to_event())
+        
+        self.assertEqual(partial2.index, partial1.index)
+        self.assertEqual(partial2.precincts[0], partial1.precincts[0])
+        self.assertEqual(partial2.tiles, partial1.tiles)
+        self.assertEqual(str(partial2.geometry), str(partial1.geometry))
+    
+    def test_Partial_scrunching(self):
+        ''' Partial.scrunch() and .unscrunch() work symmetrically.
+        '''
+        for value in [None, 0, False, True, 'Yo']:
+            self.assertEqual(districts.Partial.unscrunch(districts.Partial.scrunch(value)),
+                value, 'Simple scalar values should unscrunch cleanly')
+
+        for value in [['Yo'], {'Yo': 'Yo'}]:
+            self.assertEqual(districts.Partial.unscrunch(districts.Partial.scrunch(value)),
+                value, 'Lists and dictionaries should unscrunch cleanly')
+            self.assertEqual(districts.Partial.unscrunch(value), value,
+                'Lists and dictionaries should unscrunch to themselves')
 
     @unittest.mock.patch('boto3.client')
     @unittest.mock.patch('planscore.districts.consume_tiles')

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -88,9 +88,9 @@ class TestScore (unittest.TestCase):
         geometry = ogr.CreateGeometryFromJson(json.dumps(feature['geometry']))
         totals, tiles, _ = score.score_district(s3, bucket, geometry, 'NC')
         
-        self.assertAlmostEqual(totals['Voters'], 124011.6413881468)
-        self.assertAlmostEqual(totals['Blue Votes'], 12717.196301225393)
-        self.assertAlmostEqual(totals['Red Votes'], 15607.833841392498)
+        self.assertAlmostEqual(totals['Voters'], 87695.33161001765)
+        self.assertAlmostEqual(totals['Blue Votes'], 8474.991380678142)
+        self.assertAlmostEqual(totals['Red Votes'], 13157.538612555834)
         self.assertEqual(tiles, ['10/276/403'])
     
     def test_score_district_missing_tile(self):


### PR DESCRIPTION
Leaving adequate time (15sec) for follow-up invocation, and scrunching event data down with ASCII-encoded gzip compression. Now we’re recursing. Part of #21.