### PR TITLE
Add space for plan descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: planscore/website/build
 
 live-lambda: planscore-lambda.zip
 	env AWS=amazonaws.com WEBSITE_BASE=https://planscore.org/ \
-		parallel ./deploy.py planscore-lambda.zip \
+		parallel -j4 ./deploy.py planscore-lambda.zip \
 		:::  PlanScore-UploadFields PlanScore-AfterUpload PlanScore-RunDistrict PlanScore-ScoreDistrictPlan
 
 live-website: planscore/website/build

--- a/data/sample-NC-1-992/index.json
+++ b/data/sample-NC-1-992/index.json
@@ -198,6 +198,7 @@
   ],
   "id": "20170611T160839.739395328Z",
   "key": "uploads/20170611T160839.739395328Z/upload/NC-plan-1-992.geojson",
+  "description": "This plan is okay.",
   "summary": {
     "Efficiency Gap": null,
     "SLDL Efficiency Gap": -0.09074382226675635,

--- a/debug-site.py
+++ b/debug-site.py
@@ -2,4 +2,6 @@
 import planscore.website
 
 if __name__ == '__main__':
+    planscore.website.app.jinja_env.auto_reload = True
+    planscore.website.app.config['TEMPLATES_AUTO_RELOAD'] = True
     planscore.website.app.run(debug=True)

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -251,14 +251,15 @@ function hide_message(score_section, message_section)
     message_section.style.display = 'none';
 }
 
-function load_plan_score(url, fields, score_section, message_section, table, score_EG, score_pop, score_dem, map_url, map_div)
+function load_plan_score(url, fields, message_section, score_section,
+    description, table, score_EG, score_pop, score_dem, map_url, map_div)
 {
     var request = new XMLHttpRequest();
     request.open('GET', url, true);
     
     show_message('Loading district plan…', score_section, message_section);
 
-    function on_loaded_score(plan)
+    function on_loaded_score(plan, modified_at)
     {
         if(which_score_summary_name(plan) === null) {
             show_message('District plan failed to load.', score_section, message_section);
@@ -267,7 +268,19 @@ function load_plan_score(url, fields, score_section, message_section, table, sco
         } else {
             hide_message(score_section, message_section);
         }
-    
+        
+        // Clear out and repopulation description.
+        clear_element(description);
+        
+        description.innerHTML = 'Nar nar nar';
+
+        description.appendChild(document.createElement('br'));
+        description.appendChild(document.createElement('i'));
+        description.lastChild.appendChild(document.createTextNode(
+            ((new Date()).getTime()/1000 - modified_at.getTime()/1000 > 86400)
+                ? 'Uploaded on '+ modified_at.toLocaleDateString()
+                : 'Uploaded at '+ modified_at.toLocaleString()));
+        
         // Build list of columns
         var current_column = ['District'],
             all_columns = [current_column],
@@ -345,9 +358,10 @@ function load_plan_score(url, fields, score_section, message_section, table, sco
         if(request.status >= 200 && request.status < 400)
         {
             // Returns a dictionary with a list of districts
-            var data = JSON.parse(request.responseText);
+            var data = JSON.parse(request.responseText),
+                modified_at = new Date(request.getResponseHeader('Last-Modified'));
             console.log('Loaded plan:', data);
-            on_loaded_score(data);
+            on_loaded_score(data, modified_at);
         }
     };
 

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -45,6 +45,16 @@ function date_age(date)
     return (new Date()).getTime() / 1000 - date.getTime() / 1000;
 }
 
+function what_score_description(plan)
+{
+    if(typeof plan['description'] === 'string')
+    {
+        return plan['description'];
+    }
+    
+    return '<i>No description provided</i>';
+}
+
 function which_score_summary_name(plan)
 {
     var summaries = [
@@ -277,8 +287,7 @@ function load_plan_score(url, fields, message_section, score_section,
         // Clear out and repopulation description.
         clear_element(description);
         
-        description.innerHTML = 'Nar nar nar';
-
+        description.innerHTML = what_score_description(plan);
         description.appendChild(document.createElement('br'));
         description.appendChild(document.createElement('i'));
         description.lastChild.appendChild(document.createTextNode(
@@ -441,6 +450,7 @@ if(module !== undefined)
     module.exports = {
         format_url: format_url, nice_count: nice_count,
         nice_percent: nice_percent, nice_gap: nice_gap, date_age: date_age,
+        what_score_description: what_score_description,
         which_score_summary_name: which_score_summary_name,
         which_score_column_names: which_score_column_names,
         which_district_color: which_district_color

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -45,7 +45,7 @@ function date_age(date)
     return (new Date()).getTime() / 1000 - date.getTime() / 1000;
 }
 
-function what_score_description(plan)
+function what_score_description_html(plan)
 {
     if(typeof plan['description'] === 'string')
     {
@@ -284,10 +284,10 @@ function load_plan_score(url, fields, message_section, score_section,
             hide_message(score_section, message_section);
         }
         
-        // Clear out and repopulation description.
+        // Clear out and repopulate description.
         clear_element(description);
         
-        description.innerHTML = what_score_description(plan);
+        description.innerHTML = what_score_description_html(plan);
         description.appendChild(document.createElement('br'));
         description.appendChild(document.createElement('i'));
         description.lastChild.appendChild(document.createTextNode(
@@ -450,7 +450,7 @@ if(module !== undefined)
     module.exports = {
         format_url: format_url, nice_count: nice_count,
         nice_percent: nice_percent, nice_gap: nice_gap, date_age: date_age,
-        what_score_description: what_score_description,
+        what_score_description_html: what_score_description_html,
         which_score_summary_name: which_score_summary_name,
         which_score_column_names: which_score_column_names,
         which_district_color: which_district_color

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -40,6 +40,11 @@ function clear_element(el)
     }
 }
 
+function date_age(date)
+{
+    return (new Date()).getTime() / 1000 - date.getTime() / 1000;
+}
+
 function which_score_summary_name(plan)
 {
     var summaries = [
@@ -277,7 +282,7 @@ function load_plan_score(url, fields, message_section, score_section,
         description.appendChild(document.createElement('br'));
         description.appendChild(document.createElement('i'));
         description.lastChild.appendChild(document.createTextNode(
-            ((new Date()).getTime()/1000 - modified_at.getTime()/1000 > 86400)
+            (date_age(modified_at) > 86400)
                 ? 'Uploaded on '+ modified_at.toLocaleDateString()
                 : 'Uploaded at '+ modified_at.toLocaleString()));
         
@@ -435,7 +440,7 @@ if(module !== undefined)
 {
     module.exports = {
         format_url: format_url, nice_count: nice_count,
-        nice_percent: nice_percent, nice_gap: nice_gap,
+        nice_percent: nice_percent, nice_gap: nice_gap, date_age: date_age,
         which_score_summary_name: which_score_summary_name,
         which_score_column_names: which_score_column_names,
         which_district_color: which_district_color

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -21,7 +21,7 @@
         Loading plan…
     </section>
     <section id="plan-score">
-    <p>Blah blah blah</p>
+    <p id="plan-description">Blah blah blah</p>
     <ul id="scores-box">
         {# these list items will be populated by load_plan_score() #}
 
@@ -58,8 +58,9 @@
 	        geom_url = format_url('{{ geom_url_pattern }}', plan_id);
 
 	    load_plan_score(plan_url, fields,
-	        document.getElementById('plan-score'),
 	        document.getElementById('message'),
+	        document.getElementById('plan-score'),
+	        document.getElementById('plan-description'),
 	        document.getElementById('districts'),
 	        document.getElementById('score-efficiency-gap'),
 	        document.getElementById('score-population'),

--- a/tests.js
+++ b/tests.js
@@ -7,6 +7,9 @@ var NC_index = require('data/sample-NC-1-992/index.json'),
 
 // Old-style red vs. blue plan
 
+assert.equal(plan.what_score_description(NC_simple_index),
+    '<i>No description provided</i>', 'Should find the right description');
+
 assert.equal(plan.which_score_summary_name(NC_simple_index),
     'Efficiency Gap', 'Should pick out the right summary name');
 
@@ -21,6 +24,9 @@ assert.equal(plan.which_district_color(NC_simple_index.districts[7], NC_simple_i
 
 // Incomplete plan, seen just after upload but before scoring is complete
 
+assert.equal(plan.what_score_description(NC_incomplete_index),
+    '<i>No description provided</i>', 'Should find the right description');
+
 assert.strictEqual(plan.which_score_summary_name(NC_incomplete_index),
     null, 'Should return a null summary name');
 
@@ -28,6 +34,9 @@ assert.deepEqual(plan.which_score_column_names(NC_incomplete_index),
     [], 'Should return an empty list of column names');
 
 // North Carolina plan with named house and parties
+
+assert.equal(plan.what_score_description(NC_index),
+    'This plan is okay.', 'Should find the right description');
 
 assert.equal(plan.which_score_summary_name(NC_index),
     'US House Efficiency Gap', 'Should pick out the right summary name');

--- a/tests.js
+++ b/tests.js
@@ -7,7 +7,7 @@ var NC_index = require('data/sample-NC-1-992/index.json'),
 
 // Old-style red vs. blue plan
 
-assert.equal(plan.what_score_description(NC_simple_index),
+assert.equal(plan.what_score_description_html(NC_simple_index),
     '<i>No description provided</i>', 'Should find the right description');
 
 assert.equal(plan.which_score_summary_name(NC_simple_index),
@@ -24,7 +24,7 @@ assert.equal(plan.which_district_color(NC_simple_index.districts[7], NC_simple_i
 
 // Incomplete plan, seen just after upload but before scoring is complete
 
-assert.equal(plan.what_score_description(NC_incomplete_index),
+assert.equal(plan.what_score_description_html(NC_incomplete_index),
     '<i>No description provided</i>', 'Should find the right description');
 
 assert.strictEqual(plan.which_score_summary_name(NC_incomplete_index),
@@ -35,7 +35,7 @@ assert.deepEqual(plan.which_score_column_names(NC_incomplete_index),
 
 // North Carolina plan with named house and parties
 
-assert.equal(plan.what_score_description(NC_index),
+assert.equal(plan.what_score_description_html(NC_index),
     'This plan is okay.', 'Should find the right description');
 
 assert.equal(plan.which_score_summary_name(NC_index),

--- a/tests.js
+++ b/tests.js
@@ -47,6 +47,10 @@ assert.equal(plan.which_district_color(NC_index.districts[7], NC_index),
 
 // Assorted functions
 
+assert(plan.date_age(new Date('1970-01-01')) > 86400 * 365);
+assert(plan.date_age(new Date('2017-10-01')) < 86400 * 365 * 5);
+assert(plan.date_age(new Date()) < 1);
+
 assert.equal(plan.nice_count(7654321), '7654.3k', 'Should not have a thousands separator');
 assert.equal(plan.nice_count(4321), '4.3k', 'Should show numbers in thousands');
 assert.equal(plan.nice_count(321), '321', 'Should see a literal integer');


### PR DESCRIPTION
Adds a `plan.description` property expected to contain HTML, and shows it on Plan pages if it exists along with last-modified dates.